### PR TITLE
TEXTSEARCH: Add @@ operator, remove useless overload of toTsVector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 build/
+.gradle/

--- a/src/main/kotlin/epgx/functions/Comparisons.kt
+++ b/src/main/kotlin/epgx/functions/Comparisons.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.CustomFunction
 
 /**
- * Checks if [this] tsvector column is equals to some [tsQuery] query.
+ * Checks if [this] tsvector column is matches to some [tsQuery] query.
  */
 @Suppress("FunctionName")
 infix fun <T> Column<T>.`@@`(tsQuery: CustomFunction<*>): AtAtOp =

--- a/src/main/kotlin/epgx/functions/Comparisons.kt
+++ b/src/main/kotlin/epgx/functions/Comparisons.kt
@@ -5,5 +5,5 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.CustomFunction
 
 @Suppress("FunctionName")
-infix fun <T> Column<T>.`@@`(TsQuery: CustomFunction<*>): AtAtOp =
-        AtAtOp(this, TsQuery)
+infix fun <T> Column<T>.`@@`(tsQuery: CustomFunction<*>): AtAtOp =
+        AtAtOp(this, tsQuery)

--- a/src/main/kotlin/epgx/functions/Comparisons.kt
+++ b/src/main/kotlin/epgx/functions/Comparisons.kt
@@ -5,7 +5,7 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.CustomFunction
 
 /**
- * Checks if [this] tsvector column is matches to some [tsQuery] query.
+ * Checks if [this] tsvector column matches [tsQuery] query.
  */
 @Suppress("FunctionName")
 infix fun <T> Column<T>.`@@`(tsQuery: CustomFunction<*>): AtAtOp =

--- a/src/main/kotlin/epgx/functions/Comparisons.kt
+++ b/src/main/kotlin/epgx/functions/Comparisons.kt
@@ -1,0 +1,9 @@
+package epgx.functions
+
+import epgx.ops.AtAtOp
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.CustomFunction
+
+@Suppress("FunctionName")
+infix fun <T> Column<T>.`@@`(TsQuery: CustomFunction<*>): AtAtOp =
+        AtAtOp(this, TsQuery)

--- a/src/main/kotlin/epgx/functions/Comparisons.kt
+++ b/src/main/kotlin/epgx/functions/Comparisons.kt
@@ -4,6 +4,9 @@ import epgx.ops.AtAtOp
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.CustomFunction
 
+/**
+ * Checks if [this] tsvector column is equals to some [tsQuery] query.
+ */
 @Suppress("FunctionName")
 infix fun <T> Column<T>.`@@`(tsQuery: CustomFunction<*>): AtAtOp =
         AtAtOp(this, tsQuery)

--- a/src/main/kotlin/epgx/functions/TsVectorFunctions.kt
+++ b/src/main/kotlin/epgx/functions/TsVectorFunctions.kt
@@ -18,18 +18,3 @@ fun <T : String?> Expression<T>.toTsVector(language: String? = null): CustomFunc
         CustomFunction("to_tsvector", TsVectorColumnType(), this)
     else
         CustomFunction("to_tsvector", TsVectorColumnType(), QueryParameter(language, TextColumnType()), this)
-
-/**
- * Creates a `tsvector` expression from a column.
- *
- * @param language the `regconfig` to use
- *
- * @author Benjozork
- *
- * [PostgreSQL Documentation](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-DOCUMENTS)
- */
-fun <T : Any> Column<T>.toTsVector(language: String? = null): CustomFunction<TsVectorColumnType> =
-    if (language == null)
-        CustomFunction("to_tsvector", TsVectorColumnType(), this)
-    else
-        CustomFunction("to_tsvector", TsVectorColumnType(), QueryParameter(language, TextColumnType()), this)

--- a/src/main/kotlin/epgx/ops/AtAtOp.kt
+++ b/src/main/kotlin/epgx/ops/AtAtOp.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.sql.ComparisonOp
 import org.jetbrains.exposed.sql.Expression
 
 /**
- * Represents an SQL operator that checks if [vector] is matches to a [query] or vice versa.
+ * Represents an SQL operator that checks if [vector] matches [query].
  */
 class AtAtOp(
         vector: Expression<*>,

--- a/src/main/kotlin/epgx/ops/AtAtOp.kt
+++ b/src/main/kotlin/epgx/ops/AtAtOp.kt
@@ -3,6 +3,9 @@ package epgx.ops
 import org.jetbrains.exposed.sql.ComparisonOp
 import org.jetbrains.exposed.sql.Expression
 
+/**
+ * Represents an SQL operator that checks if [vector] is equals to [query].
+ */
 class AtAtOp(
         vector: Expression<*>,
         query: Expression<*>

--- a/src/main/kotlin/epgx/ops/AtAtOp.kt
+++ b/src/main/kotlin/epgx/ops/AtAtOp.kt
@@ -1,0 +1,9 @@
+package epgx.ops
+
+import org.jetbrains.exposed.sql.ComparisonOp
+import org.jetbrains.exposed.sql.Expression
+
+class AtAtOp(
+        vector: Expression<*>,
+        query: Expression<*>
+) : ComparisonOp(vector, query, "@@")

--- a/src/main/kotlin/epgx/ops/AtAtOp.kt
+++ b/src/main/kotlin/epgx/ops/AtAtOp.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.sql.ComparisonOp
 import org.jetbrains.exposed.sql.Expression
 
 /**
- * Represents an SQL operator that checks if [vector] is equals to [query].
+ * Represents an SQL operator that checks if [vector] is matches to a [query] or vice versa.
  */
 class AtAtOp(
         vector: Expression<*>,


### PR DESCRIPTION
Changes
- Make the code compile if `toTsVector` function is used
- Allow tsvector column to be compared with a tsquery